### PR TITLE
Ability to specify if the database connection is secure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 BOT_TOKEN=
 DATABASE_URL="postgres://user:password@Server/database"
+DATABASE_SECURE=true

--- a/BigBenClock/index.js
+++ b/BigBenClock/index.js
@@ -15,7 +15,7 @@ class BigBenClock {
         this.botToken = process.env.BOT_TOKEN;
 
         // Database instance
-        this.database = new Database(process.env.DATABASE_URL);
+        this.database = new Database(process.env.DATABASE_URL, { ssl: process.env.DATABASE_SECURE });
 
         // Create the bot
         this.bot = new Discord.Client();

--- a/Database/index.js
+++ b/Database/index.js
@@ -5,9 +5,12 @@ class Database {
      * Database constructor
      * @param connectionString
      */
-    constructor(connectionString) {
+    constructor(connectionString, options) {
         // connection URI
         this.connectionString = connectionString;
+
+        // Database client options
+        this.options = options || {};
 
         // Database instance
         this.db = null;
@@ -18,7 +21,7 @@ class Database {
      * @returns {Promise<void>}
      */
     async init() {
-        this.db = new Client({ connectionString: this.connectionString });
+        this.db = new Client(Object.assign({ connectionString: this.connectionString }, this.options));
 
         // Attempt to connect
         await this.db.connect();

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ RUN npm install
 
 ENV BOT_TOKEN=
 ENV DATABASE_URL=
+ENV DATABASE_SECURE=
 
 CMD npm run migrate up && npm run start

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains the source code for a discord bot that chimes every hou
 If you want to run the big-ben clock discord bot on docker you can do that with the following command:
    
 ```
-docker run --name BigBen-Bot --env BOT_TOKEN="<Replace with Discord-Bot Token>" --env DATABASE_URL="postgres://username:password@IP/Localhost:5432/DatabaseName" kippenhof/bigbendiscord
+docker run --name BigBen-Bot --env BOT_TOKEN="<Replace with Discord-Bot Token>" --env DATABASE_URL="postgres://username:password@IP/Localhost:5432/DatabaseName" --env DATABASE_SECURE=true kippenhof/bigbendiscord
 ``` 
 
 


### PR DESCRIPTION
Added ability to specify if the database connection is using a secure connection.

Initial work to allow for expansion of options in the future

New env variable `DATABASE_SECURE` that will default to `false` (current logic) if not provided within environment